### PR TITLE
Send REST call to BE to save feedback, and informs the user 

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,6 +5,8 @@ import { AppComponent } from './app.component';
 import { LoginComponent } from './login/login.component';
 import { FeedbackComponent } from './feedback/feedback.component';
 import {RouterModule, Routes} from '@angular/router';
+import { HttpModule } from '@angular/http';
+import {FeedbackService} from './feedback/feedback.service';
 
 const appRoutes: Routes = [
   { path: 'feedback', component: FeedbackComponent },
@@ -21,9 +23,10 @@ const appRoutes: Routes = [
     RouterModule.forRoot(appRoutes,  { enableTracing: true }),
     BrowserModule,
     FormsModule,
-    ReactiveFormsModule
+    ReactiveFormsModule,
+    HttpModule
   ],
-  providers: [],
+  providers: [ FeedbackService ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/feedback/feedback.component.html
+++ b/src/app/feedback/feedback.component.html
@@ -17,6 +17,7 @@
       </div>
 
       <input type="submit" class="button expanded" value="Submit Form" [disabled]="!fbkForm.valid">
-    </div>
+      <div class="alert" *ngIf="responseMessage">{{ responseMessage }}</div>
+      </div>
   </div>
 </form>

--- a/src/app/feedback/feedback.component.ts
+++ b/src/app/feedback/feedback.component.ts
@@ -1,32 +1,44 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import {FeedbackService} from './feedback.service';
 
 
 @Component({
   templateUrl: './feedback.component.html',
   styleUrls: ['./feedback.component.css']
 })
-export class FeedbackComponent implements OnInit {
+export class FeedbackComponent {
 
   fbkForm: FormGroup;
-  title: string;
-  description: string;
-  post: any;
+  responseMessage: string;
 
-  constructor(private _formBuilder: FormBuilder) {
+  constructor(private _formBuilder: FormBuilder, private  _feedbackService: FeedbackService) {
     this.fbkForm = _formBuilder.group({
       'title': [null, Validators.required],
       'description': [null, Validators.compose([Validators.required, Validators.minLength(10), Validators.maxLength(500)])]
     });
+    // Disappear the message if the user is editing the form again
+    this.fbkForm.valueChanges.subscribe(data => {
+      this.responseMessage = null;
+    });
   }
   addPost(post) {
-    this.title = post.title;
-    this.description = post.description;
-    // TODO: Need to send HTTP POST request to BE server to save the feedback
-    console.log('Received request for the ' + this.title + ' feedback');
+    const feedback = {
+      title: post.title,
+      feedbackBody: post.description,
+      // Hard-coding the idea of feedback-for at the moment
+      feedbackFor: 'Ravinderakash'
+    };
+    // Login module will determine the "userId", so assuming it is 2 for now
+    this._feedbackService.saveFeedback('2', feedback)
+      .subscribe(addedFeedback => {
+          console.log('Feedback was successful: ' + JSON.stringify(addedFeedback));
+          this.fbkForm.reset();
+          this.responseMessage = 'Feedback was successfully submitted';
+        },
+      err => {
+        console.log('Error was logged : ' + err);
+        this.responseMessage = 'Feedback was not submitted successfully submitted. Please try again!';
+      });
   }
-
-  ngOnInit() {
-  }
-
 }

--- a/src/app/feedback/feedback.service.spec.ts
+++ b/src/app/feedback/feedback.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { FeedbackService } from './feedback.service';
+
+describe('FeedbackService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [FeedbackService]
+    });
+  });
+
+  it('should be created', inject([FeedbackService], (service: FeedbackService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/feedback/feedback.service.ts
+++ b/src/app/feedback/feedback.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import {Headers, Http, RequestOptions, Response} from '@angular/http';
+import {Observable} from 'rxjs/Observable';
+import {Feedback} from './feedback';
+import 'rxjs/Rx';
+
+@Injectable()
+export class FeedbackService {
+
+  baseurl = 'http://localhost:10010/';
+  userPath = 'user/';
+  feedbackPath = '/feedbacks';
+
+  constructor(private http: Http) { }
+
+  saveFeedback(userId, feedback): Observable<Feedback> {
+    const postHeader = new Headers({ 'Content-Type': 'application/json' });
+    const options = new RequestOptions({ headers: postHeader });
+    return this.http.post(this.baseurl + this.userPath + userId + this.feedbackPath , feedback, options)
+      .map((res: Response) => res.json())
+      .catch((error: any) => Observable.throw(error.json().error || 'Server error'));
+  }
+
+}

--- a/src/app/feedback/feedback.ts
+++ b/src/app/feedback/feedback.ts
@@ -1,0 +1,9 @@
+export class Feedback {
+
+  constructor(
+    public _id: string,
+    public feedbackFor: string,
+    public title: string,
+    public feedbackBody: string
+  ) {}
+}


### PR DESCRIPTION
Sends REST request to an active backend server, which has the `add-feedback-endpoints` branch (until its merged to master), and saves the feedback for the user.

As the feedbackFor is not planned yet, thus assuming the feedback is for the website "Ravinderakash" itself. Also as the userId dependency would come from the Login/SignUp module, thus assuming its the userId 2 who is submitting feedback.